### PR TITLE
Drag&Drop done

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,7 +76,7 @@ img {
 }
 body {
   background-color: ${(props) => props.theme.bgColor};
-  color: black;
+  color: ${(props) => props.theme.textColor};
 }
 a {
   text-decoration: none;

--- a/src/Components/Navigator.tsx
+++ b/src/Components/Navigator.tsx
@@ -25,12 +25,12 @@ const ButtonTitle = styled.h1`
   display: flex;
   justify-content: center;
   align-items: center;
-  color: white;
+  color: ${(props) => props.theme.textColor};
 `;
 const ButtonIndicator = styled(motion.div)`
   width: 100px;
   height: 2px;
-  background-color: red;
+  background-color: ${(props) => props.theme.cardColor};
 `;
 
 function Navigator() {

--- a/src/Components/TodoApp/Board.tsx
+++ b/src/Components/TodoApp/Board.tsx
@@ -1,94 +1,97 @@
 import React from "react";
-import { useSetRecoilState } from "recoil";
-import { IToDo, toDoState } from "../../atoms";
+import { useRecoilState } from "recoil";
+import { dragBoard, IToDo } from "../../atoms";
 import { useForm } from "react-hook-form";
 import styled from "styled-components";
-import { Droppable } from "react-beautiful-dnd";
+import { Draggable, Droppable } from "react-beautiful-dnd";
 import Card from "./Card";
 
-const Wrapper = styled.div`
+const BoardWrapper = styled.div<{ isDragging: boolean }>`
   width: 300px;
   min-height: 300px;
-  background-color: ${(props) => props.theme.boardColor};
-  display: flex;
-  flex-direction: column;
-  border-radius: 5px;
-  padding: 10px 0;
+  margin: 5px;
+
+  background-color: ${(props) =>
+    props.isDragging ? props.theme.cardColor : props.theme.boardColor};
+  box-shadow: ${(props) =>
+    props.isDragging ? "0px 2px 5px rgba(0, 0, 0, 0.5)" : "none"};
+  transition: background-color 0.3s ease-out;
 `;
 const Title = styled.h2`
   text-align: center;
-  font-size: 18px;
-  font-weight: 700;
+  font-weight: 600;
   margin-bottom: 10px;
-`;
-const Form = styled.form`
-  width: 100%;
-  input {
-    width: 100%;
-  }
+  font-size: 18px;
 `;
 
-interface IDropAreaProps {
+interface IAreaProps {
   isDraggingOver: boolean;
   draggingFromThisWith: boolean;
 }
-const DropArea = styled.div<IDropAreaProps>`
+const CardDropArea = styled.div<IAreaProps>`
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+
   background-color: ${(props) =>
     props.isDraggingOver
-      ? "#bfd6c9"
+      ? props.theme.dropBoardColor
       : props.draggingFromThisWith
-      ? "#b2bec3"
+      ? props.theme.startBoardColor
       : "transparent"};
   transition: background-color 0.3s ease-out;
-  flex-grow: 1;
-  padding: 20px;
 `;
 
 interface IBoardProps {
-  toDos: IToDo[];
   boardId: string;
+  boardIdx: number;
+  toDos: IToDo[];
 }
 interface IForm {
   toDo: string;
 }
-function Board({ toDos, boardId }: IBoardProps) {
-  const setToDos = useSetRecoilState(toDoState);
+function Board({ boardId, boardIdx, toDos }: IBoardProps) {
+  const [isDragBoard, setIsBoardDropDisable] = useRecoilState(dragBoard);
   const { register, setValue, handleSubmit } = useForm<IForm>();
   const onValid = ({ toDo }: IForm) => {
     //TODO: add todo list
   };
 
   return (
-    <Wrapper>
-      <Title>{boardId}</Title>
-      <Form>
-        <input
-          {...register("toDo", { required: true })}
-          type="text"
-          placeholder={`Add task no ${boardId}`}
-        />
-      </Form>
-      <Droppable droppableId={boardId}>
-        {(provider, snapshot) => (
-          <DropArea
-            isDraggingOver={snapshot.isDraggingOver}
-            draggingFromThisWith={Boolean(snapshot.draggingFromThisWith)}
-            ref={provider.innerRef}
-            {...provider.droppableProps}
-          >
-            {toDos.map((toDo, idx) => (
-              <Card
-                key={toDo.id}
-                idx={idx}
-                toDoId={toDo.id}
-                toDoText={toDo.text}
-              />
-            ))}
-            {provider.placeholder}
-          </DropArea>
-        )}
-      </Droppable>
-    </Wrapper>
+    <Draggable draggableId={boardId} index={boardIdx}>
+      {(boardProvided, boardInSnapshot) => (
+        <BoardWrapper
+          isDragging={boardInSnapshot.isDragging}
+          ref={boardProvided.innerRef}
+          {...boardProvided.draggableProps}
+          {...boardProvided.dragHandleProps}
+        >
+          <Title>{boardId}</Title>
+          <Droppable droppableId={boardId} isDropDisabled={isDragBoard}>
+            {(cardProvider, cardSnapshot) => (
+              <CardDropArea
+                isDraggingOver={cardSnapshot.isDraggingOver}
+                draggingFromThisWith={Boolean(
+                  cardSnapshot.draggingFromThisWith
+                )}
+                ref={cardProvider.innerRef}
+                {...cardProvider.droppableProps}
+              >
+                {toDos.map((todo, cardIdx) => (
+                  <Card
+                    key={todo.id}
+                    cardIdx={cardIdx}
+                    cardId={todo.id}
+                    cardText={todo.text}
+                  />
+                ))}
+                {cardProvider.placeholder}
+              </CardDropArea>
+            )}
+          </Droppable>
+        </BoardWrapper>
+      )}
+    </Draggable>
   );
 }
 

--- a/src/Components/TodoApp/Card.tsx
+++ b/src/Components/TodoApp/Card.tsx
@@ -2,33 +2,35 @@ import React from "react";
 import { Draggable } from "react-beautiful-dnd";
 import styled from "styled-components";
 
-const CardContent = styled.div<{ isDragging: boolean }>`
-  background-color: ${(props) =>
-    props.isDragging ? "#74b9ff" : props.theme.cardColor};
-  box-shadow: ${(props) =>
-    props.isDragging ? "0px 2px 5px rgba(0, 0, 0, 0.5)" : "none"};
+const CardWrapper = styled.div<{ isDragging: boolean }>`
   border-radius: 5px;
   margin-bottom: 5px;
   padding: 10px;
+
+  background-color: ${(props) =>
+    props.isDragging ? props.theme.dragCardColor : props.theme.cardColor};
+  box-shadow: ${(props) =>
+    props.isDragging ? "0px 2px 5px rgba(0, 0, 0, 0.5)" : "none"};
+  transition: background-color 0.3s ease-out;
 `;
 
 interface ICardProps {
-  toDoId: number;
-  toDoText: string;
-  idx: number;
+  cardId: number;
+  cardIdx: number;
+  cardText: string;
 }
-function Card({ toDoId, toDoText, idx }: ICardProps) {
+function Card({ cardId, cardIdx, cardText }: ICardProps) {
   return (
-    <Draggable draggableId={toDoId + ""} index={idx}>
-      {(provided, snapshot) => (
-        <CardContent
-          isDragging={snapshot.isDragging}
-          ref={provided.innerRef}
-          {...provided.draggableProps}
-          {...provided.dragHandleProps}
+    <Draggable draggableId={cardId + ""} index={cardIdx}>
+      {(cardProvided, cardInSnapshot) => (
+        <CardWrapper
+          isDragging={cardInSnapshot.isDragging}
+          ref={cardProvided.innerRef}
+          {...cardProvided.draggableProps}
+          {...cardProvided.dragHandleProps}
         >
-          {toDoText}
-        </CardContent>
+          {cardText}
+        </CardWrapper>
       )}
     </Draggable>
   );

--- a/src/Routes/TodoApp.tsx
+++ b/src/Routes/TodoApp.tsx
@@ -1,44 +1,71 @@
-import { DragDropContext, DropResult } from "react-beautiful-dnd";
+import {
+  DragDropContext,
+  DragStart,
+  Droppable,
+  DropResult,
+} from "react-beautiful-dnd";
 import { useRecoilState } from "recoil";
 import styled from "styled-components";
-import { toDoState } from "../atoms";
+import { dragBoard, toDoState } from "../atoms";
 import Board from "../Components/TodoApp/Board";
 
 const Wrapper = styled.div`
   width: 100%;
   height: 100%;
 `;
-const BoardWrapper = styled.div`
-  width: 100vw;
-  height: 100vh;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  margin: 0 auto;
-`;
-const Boards = styled.div`
-  width: 100%;
+
+interface IAreaProps {
+  isDraggingOver: boolean;
+  draggingFromThisWith: boolean;
+}
+const BoardDropArea = styled.div<IAreaProps>`
+  min-width: 100%;
+  min-height: 100%;
   display: flex;
   align-items: flex-start;
   justify-content: center;
-  gap: 10px;
+  padding: 20px;
 `;
 
 function TodoApp() {
   const [toDos, setToDos] = useRecoilState(toDoState);
-
-  const onDragEnd = (info: DropResult) => {};
+  const [isDragBoard, setIsDragBoard] = useRecoilState(dragBoard);
+  const onDragEnd = (info: DropResult) => {
+    setIsDragBoard(true);
+  };
+  const onDragStart = (info: DragStart) => {
+    info.source.droppableId === "Boards_EF9026D"
+      ? setIsDragBoard(true)
+      : setIsDragBoard(false);
+  };
 
   return (
     <Wrapper>
-      <DragDropContext onDragEnd={onDragEnd}>
-        <BoardWrapper>
-          <Boards>
-            {Object.keys(toDos).map((boardId) => (
-              <Board key={boardId} boardId={boardId} toDos={toDos[boardId]} />
-            ))}
-          </Boards>
-        </BoardWrapper>
+      <DragDropContext onDragEnd={onDragEnd} onBeforeDragStart={onDragStart}>
+        <Droppable
+          droppableId="Boards_EF9026D"
+          direction="horizontal"
+          isDropDisabled={!isDragBoard}
+        >
+          {(boardProvider, boardSnapshot) => (
+            <BoardDropArea
+              isDraggingOver={boardSnapshot.isDraggingOver}
+              draggingFromThisWith={Boolean(boardSnapshot.draggingFromThisWith)}
+              ref={boardProvider.innerRef}
+              {...boardProvider.droppableProps}
+            >
+              {Object.keys(toDos).map((boardId, boardIdx) => (
+                <Board
+                  key={boardId}
+                  boardIdx={boardIdx}
+                  boardId={boardId}
+                  toDos={toDos[boardId]}
+                />
+              ))}
+              {boardProvider.placeholder}
+            </BoardDropArea>
+          )}
+        </Droppable>
       </DragDropContext>
     </Wrapper>
   );

--- a/src/atoms.tsx
+++ b/src/atoms.tsx
@@ -33,3 +33,8 @@ export const toDoState = atom<IToDoState>({
   },
   effects_UNSTABLE: [persistAtom],
 });
+
+export const dragBoard = atom<boolean>({
+  key: "dragBoard",
+  default: true,
+});

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -4,8 +4,15 @@ import "styled-components";
 // and extend them!
 declare module "styled-components" {
   export interface DefaultTheme {
+    textColor: string;
+
     bgColor: string;
+
     boardColor: string;
+    startBoardColor: string;
+    dropBoardColor: string;
+
     cardColor: string;
+    dragCardColor: string;
   }
 }

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,7 +1,14 @@
 import { DefaultTheme } from "styled-components";
 
 export const defaultTheme: DefaultTheme = {
-  bgColor: "#3f8cf2",
-  boardColor: "#dadfe9",
-  cardColor: "white",
+  textColor: "#000000",
+
+  bgColor: "#FDFDBD",
+
+  boardColor: "#F8C4B4",
+  startBoardColor: "#FF8787",
+  dropBoardColor: "#E5EBB2",
+
+  cardColor: "#FF8787",
+  dragCardColor: "#FF6464",
 };


### PR DESCRIPTION
드래그 앤 드롭 기능 구현 완료했습니다.
이번에 기능 업데이트 하면서 테마당 사용하는 컬러의 색상이 기존 3개에서 7개로 늘어났습니다.
여러분 개발하실 때 참고하세요!

## 색상표
_직접 만져보면서 알아보세요!_
- `textColor`: 기본 텍스트 색상입니다.
- `bgColor`: 배경 색상입니다.
- `boardColor`: Todo list의 보드 색상입니다.
- `startBoardColor`: 카드를 옮길 때, 카드가 있던 곳의 색상입니다.
- `dropBoardColor`: 카드를 옮길 때, 카드가 들어갈 곳의 색상입니다.
- `cardColor`: Todo list의 카드 색상입니다.
- `dragCardColor`: 카드를 옮길 때의 카드 색상입니다.